### PR TITLE
Ignore exceptions caused by non-handled events

### DIFF
--- a/src/Shared/Infrastructure/Bus/Event/InMemory/InMemorySymfonyEventBus.php
+++ b/src/Shared/Infrastructure/Bus/Event/InMemory/InMemorySymfonyEventBus.php
@@ -31,10 +31,10 @@ class InMemorySymfonyEventBus implements EventBus
 
     public function publish(DomainEvent ...$events): void
     {
-        try {
-            foreach ($events as $event) {
+        foreach ($events as $event) {
+            try {
                 $this->bus->dispatch($event);
-            }
-        } catch (NoHandlerForMessageException $error) {}
+            } catch (NoHandlerForMessageException $error) {}
+        }
     }
 }


### PR DESCRIPTION
This is useful when you queue more than one event, and there's no handlers associated to some event. In the old behavior, the following events to a non-handled event are not handled too because the triggered exception ends the loop.

With this modification, the non-handled event don't block the next events execution