### PR TITLE
Cleaning environment after each scenario instead of before in Behat tests

### DIFF
--- a/tests/src/Shared/Infrastructure/Behat/ApplicationFeatureContext.php
+++ b/tests/src/Shared/Infrastructure/Behat/ApplicationFeatureContext.php
@@ -6,6 +6,7 @@ namespace CodelyTv\Tests\Shared\Infrastructure\Behat;
 
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\PyStringNode;
+use Behat\Testwork\Hook\Scope\AfterSuiteScope;
 use CodelyTv\Shared\Infrastructure\Bus\Event\DomainEventJsonDeserializer;
 use CodelyTv\Shared\Infrastructure\Bus\Event\InMemory\InMemorySymfonyEventBus;
 use CodelyTv\Shared\Infrastructure\Doctrine\DatabaseConnections;
@@ -26,7 +27,7 @@ final class ApplicationFeatureContext implements Context
         $this->deserializer = $deserializer;
     }
 
-    /** @BeforeScenario */
+    /** @AfterScenario */
     public function cleanEnvironment(): void
     {
         $this->connections->clear();

--- a/tests/src/Shared/Infrastructure/Behat/ApplicationFeatureContext.php
+++ b/tests/src/Shared/Infrastructure/Behat/ApplicationFeatureContext.php
@@ -6,7 +6,6 @@ namespace CodelyTv\Tests\Shared\Infrastructure\Behat;
 
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\PyStringNode;
-use Behat\Testwork\Hook\Scope\AfterSuiteScope;
 use CodelyTv\Shared\Infrastructure\Bus\Event\DomainEventJsonDeserializer;
 use CodelyTv\Shared\Infrastructure\Bus\Event\InMemory\InMemorySymfonyEventBus;
 use CodelyTv\Shared\Infrastructure\Doctrine\DatabaseConnections;


### PR DESCRIPTION
Cleaning environment after each scenario instead of before in Behat tests, otherwise course_counter table is not empty when tests finishes.

I am not sure whether this is the best option or not. Maybe it would be better call cleanEnvironment method before each scenario and then make a new method which will be called after each suite.

The problem is the method called after each suite in Behat has to be static and it wouldn't be able to call the cleanEnvironment method, for that reason I don't know what is the best way to do that.

Another way to solve this bug is call the cleanEnvironment method before and after each scenario but it is not the most efficient way to solved.

What do you thing about that? What is the best way to solve that?


