### PR TITLE
Replace clevyr/prestissimo by yonex/prestissimo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ composer-install: CMD=install
 composer-update: CMD=update
 composer composer-install composer-update:
 	@docker run --rm --interactive --volume $(current-dir):/app --user $(id -u):$(id -g) \
-		clevyr/prestissimo $(CMD) \
+		yonex/prestissimo $(CMD) \
 			--ignore-platform-reqs \
 			--no-ansi \
 			--no-interaction


### PR DESCRIPTION
When you execute "make build" clevyr/prestissimo throw an error:

"install: unrecognized option: ignore-platform-reqs"

If you use yonex/prestissimo instead clevyr/prestissimo all works fine :)