### PR TITLE
Add support for updating existing courses in EloquentCourseRepository

### DIFF
--- a/src/Mooc/Courses/Infrastructure/Persistence/EloquentCourseRepository.php
+++ b/src/Mooc/Courses/Infrastructure/Persistence/EloquentCourseRepository.php
@@ -15,12 +15,13 @@ final class EloquentCourseRepository implements CourseRepository
 {
     public function save(Course $course): void
     {
-        $model           = new CourseEloquentModel();
-        $model->id       = $course->id()->value();
-        $model->name     = $course->name()->value();
-        $model->duration = $course->duration()->value();
+        $id = $course->id()->value();
 
-        $model->save();
+        CourseEloquentModel::updateOrCreate(compact('id'), [
+            'id' => $id,
+            'name' => $course->name()->value(),
+            'duration' => $course->duration()->value(),
+        ]);
     }
 
     public function search(CourseId $id): ?Course


### PR DESCRIPTION
By trying to save an existing course with the previous version of `save`, an integrity exception was thrown. This could have been solved by telling Eloquent that the record already exists with `$model->exists = true;` but by doing so, we would break inserts.

To fix the issue without having to write separated methods for **insert**s and **update**s, we used Eloquent's `updateOrCreate`.